### PR TITLE
Fix for the profile image

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -107,7 +107,7 @@ a {
 .picture {
     padding-top: 100%;
     position: relative;
-    width: 100;
+    width: 100%;
 }
 
 .picture-shadow {


### PR DESCRIPTION
Just on mobile, the profile image disappears. On Chrome and Safari desktop is working fine. But on mobile Android or iOS not. 